### PR TITLE
[ADD] res_partner_fiscal_position

### DIFF
--- a/res_partner_fiscal_position/__init__.py
+++ b/res_partner_fiscal_position/__init__.py
@@ -1,0 +1,1 @@
+import model

--- a/res_partner_fiscal_position/__openerp__.py
+++ b/res_partner_fiscal_position/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2013 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Country fiscal position',
+    'version': '7.0',
+    'category': 'Accounting',
+    'description': '''
+     This module automatically select the fiscal position from the country table. 
+     based on the module account_fiscal_position_country of agilebg. 
+    ''',
+    'author': 'Therp BV',
+    'website': 'http://www.therp.nl',
+    'depends': [
+        'base',
+        'account',
+    ],
+    'data': [
+        'view/res_country.xml',
+        'view/res_partner.xml',
+    ],
+    "installable": True,
+}

--- a/res_partner_fiscal_position/model/__init__.py
+++ b/res_partner_fiscal_position/model/__init__.py
@@ -1,0 +1,2 @@
+import res_partner
+import res_country

--- a/res_partner_fiscal_position/model/__init__.py
+++ b/res_partner_fiscal_position/model/__init__.py
@@ -1,2 +1,3 @@
-import res_partner
-import res_country
+from . import res_partner
+from . import res_country
+from . import account_fiscal_position

--- a/res_partner_fiscal_position/model/account_fiscal_position.py
+++ b/res_partner_fiscal_position/model/account_fiscal_position.py
@@ -1,0 +1,40 @@
+#-*- coding: utf-8 -*-
+'''Enhance account.fiscla.position to show company'''
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm, fields
+
+
+class AccountFiscalPosition(orm.Model):
+    '''Add company if possible to name of fiscal position.'''
+    _inherit = ['account.fiscal.position']
+                                                                               
+    def name_get(self, cr, uid, ids, context=None):                            
+        '''Return name, including company.'''                        
+        reads = self.read(                                                     
+            cr, uid, ids, ['name', 'company_id'], context=context)                    
+        res = []                                                               
+        for record in reads:
+            if record['company_id']:
+                name = record['company_id'][1] + ' ' + record['name']
+            else:
+                name = record['name']
+            res.append((record['id'], name))                                   
+        return res                                                             

--- a/res_partner_fiscal_position/model/account_fiscal_position.py
+++ b/res_partner_fiscal_position/model/account_fiscal_position.py
@@ -24,7 +24,7 @@ from openerp.osv import orm, fields
 
 class AccountFiscalPosition(orm.Model):
     '''Add company if possible to name of fiscal position.'''
-    _inherit = ['account.fiscal.position']
+    _inherit = 'account.fiscal.position'
                                                                                
     def name_get(self, cr, uid, ids, context=None):                            
         '''Return name, including company.'''                        

--- a/res_partner_fiscal_position/model/res_country.py
+++ b/res_partner_fiscal_position/model/res_country.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2011 Agile Business Group sagl (<http://www.agilebg.com>)
+#    Copyright (C) 2011 Domsense srl (<http://www.domsense.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from osv import fields, osv
+
+
+class Country(osv.osv):
+    _inherit = 'res.country'
+    _columns = {
+        #   'fiscal_position_id': fields.many2one(
+        #   'account.fiscal.position','Default fiscal position'),
+        'property_account_position': fields.property
+        ('account.fiscal.position',
+            type='many2one',
+            relation='account.fiscal.position',
+            string="Default Fiscal Position",
+            method=True,
+            view_load=True,
+            help="""The fiscal position will determine
+                 taxes and the accounts used for the country,
+                 if not set specifically elsewere.""",),
+    }
+Country()

--- a/res_partner_fiscal_position/model/res_partner.py
+++ b/res_partner_fiscal_position/model/res_partner.py
@@ -1,0 +1,36 @@
+#-*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm
+
+
+class ResPartner(orm.Model):
+    _inherit = 'res.partner'
+
+    def on_change_country_id(
+            self, cr, uid, ids, country_id, context=None):
+
+        if not country_id:
+            return {}
+        country = self.pool['res.country'].browse(cr, uid,
+                                                  country_id, context=context)
+        fis_pos_id = country.property_account_position.id
+
+        return {'value': {'property_account_position': fis_pos_id}}

--- a/res_partner_fiscal_position/view/res_country.xml
+++ b/res_partner_fiscal_position/view/res_country.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="res_partner_fiscal_position_form">
+            <field name="name">res.partner.fiscal.position.form</field>
+            <field name="model">res.country</field>
+            <field name="inherit_id" ref="base.view_country_form"/>
+            <field name="arch" type="xml">
+                <field name="code" position="after">
+                    <field name="property_account_position" widget="selection"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+

--- a/res_partner_fiscal_position/view/res_partner.xml
+++ b/res_partner_fiscal_position/view/res_partner.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="view_base_form_fiscal_position">
+            <field name="name">res.partner.fiscal.position.form</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+
+                 <field name="country_id" position="replace"> 
+                     <field name="country_id" on_change="on_change_country_id(country_id)" placeholder="Country"/> 
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
From https://code.launchpad.net/~lfreeke/therp-addons/7.0-res_partner_fiscal_position/+merge/235155 by @NL66278 and @lfreeke

@StefanRijnhart 

> Thanks! Looks really useful. Some comments:
> 
> If I understand correctly, name_get() was modified to display the company of the fiscal position, because in a >superior company the fiscal positions of the underlying companies are accessible. This could help the user >not to pick a fiscal position of any other company than the one it is working for at that moment, but it does >not prevent a mixup of company data. I would prefer to filter the fiscal positions on the current user's >company. You may have to create a function field on res.country to be able to access this piece of data >though.
> 
> In the manifest, please explain what is different in this module from the module that it is based on.
> 
> The object instantiation in line number 150 is not needed in recent versions of Odoo and should be >removed.
> 
> Please remove commented code in ll.136,137
