### PR TITLE
[FIX] Prevent security error in mail form

### DIFF
--- a/fetchmail_inbox/views/mail_message.xml
+++ b/fetchmail_inbox/views/mail_message.xml
@@ -15,6 +15,9 @@
                     <field name="attachment_ids" nolabel="1" />
                 </group>
             </xpath>
+            <field name="tracking_value_ids" position="attributes">
+                <attribute name="groups">base.group_system</attribute>
+            </field>
         </field>
     </record>
     <record id="tree_mail_message_fetchmail_inbox" model="ir.ui.view">


### PR DESCRIPTION
Model is not readable for non-admin users (https://github.com/odoo/odoo/blob/10.0/addons/mail/security/ir.model.access.csv#L26-L29)