### PR TITLE
[IMP] override_mail_recipients. Allow whitelisted domain.

### DIFF
--- a/override_mail_recipients/README.rst
+++ b/override_mail_recipients/README.rst
@@ -5,7 +5,7 @@ This module allows you to override all outgoing messages' `to`, `cc`, and `bcc`
 values for testing purposes.
 
 After installation, set the config parameter
-`override_mail_recipients.override_to` to the email address you want
+`override_mail_recipients.override_email_to` to the email address you want
 to send the testmails to.
 
 After installing this module the parameter will contain text, but not a valid
@@ -17,3 +17,8 @@ by comma's.
 
 To resume normal mail processing, set this parameter to 'disable'
 (literally). Or you could just uninstall this module.
+
+You can also set the config parameter
+`override_mail_recipients.domain_whitelist`.
+enter one ore more smtp domain names, separated by comma. This will
+cause mails to these domains to be processed in the normal way.

--- a/override_mail_recipients/__manifest__.py
+++ b/override_mail_recipients/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Override mail recipients",
-    "version": "11.0.0.1.0",
+    "version": "11.0.0.2.0",
     "author": "Therp BV",
     "license": "AGPL-3",
     "category": "Tools",

--- a/override_mail_recipients/data/ir_config_parameter.xml
+++ b/override_mail_recipients/data/ir_config_parameter.xml
@@ -3,7 +3,18 @@
 
     <record id="override_email_to" model="ir.config_parameter">
         <field name="key">override_mail_recipients.override_to</field>
-        <field name="value">your test email</field>
+        <field
+            name="value"
+            >add one or more email addresses, comma separated</field>
+    </record>
+
+    <record id="domain_whitelist" model="ir.config_parameter">
+        <field
+            name="key"
+            >override_mail_recipients.domain_whitelist</field>
+        <field
+            name="value"
+            >add one or more mail domains, comma separated</field>
     </record>
 
 </odoo>

--- a/override_mail_recipients/models/ir_mail_server.py
+++ b/override_mail_recipients/models/ir_mail_server.py
@@ -1,49 +1,28 @@
+"""Make sure no unwanted mail leaves the server."""
 # Copyright 2015-2019 Therp BV <https://therp.nl>.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import re
+
 from email.utils import COMMASPACE
 
 from odoo import api, models
 from odoo.addons.base.ir.ir_mail_server import extract_rfc2822_addresses
 
 
+ADDRESS_REPLACEMENTS = {
+    '\\': '',  # Remove backslash
+    '"': '\\"',  # escape double quote
+    '<': '[',  # open actual address part
+    '>': ']',  # close actual address part
+    '@': '(at)'}
+REPLACE_KEYS = sorted(ADDRESS_REPLACEMENTS, key=len, reverse=True)
+REPLACE_REGEX = re.compile('|'.join(map(re.escape, REPLACE_KEYS)))
+
+
 class IrMailServer(models.Model):
+    """Make sure no unwanted mail leaves the server."""
     # pylint: disable=too-few-public-methods
     _inherit = 'ir.mail_server'
-
-    @api.model
-    def patch_message(self, message):
-        """Override message recipients.
-
-        Result is dependent on what is specified in the configuration:
-        1. Message is not changed (no configuration or 'disabled');
-        2. Message recipients are replaced;
-        3. There is no valid recipient in the override configuration.
-
-        If there is no valid recipient, an Exception will be thrown. This
-        will be an AssertionException, in line with what is done by standard
-        Odoo. Most likely this message will be catched and an appropiate
-        reason for non delivery registered.
-        """
-        override_email_id = self.env.ref(
-            'override_mail_recipients.override_email_to',
-            raise_if_not_found=False)
-        if not override_email_id or \
-                not override_email_id.value or \
-                override_email_id.value == 'disable':
-            return
-        actual_recipients = extract_rfc2822_addresses(override_email_id.value)
-        assert actual_recipients, 'No valid override_email_to'
-        for field in ['to', 'cc', 'bcc']:
-            if not message[field]:
-                continue
-            original = COMMASPACE.join(message.get_all(field, []))
-            not_so_original = original.replace('\\', '').replace(
-                '"', '\\"').replace('<', '[').replace('>', ']').replace(
-                    '@', '(at)')
-            del message[field]
-            message[field] = COMMASPACE.join(
-                '"%s" <%s>' % (not_so_original, email)
-                for email in actual_recipients)
 
     @api.model
     def send_email(
@@ -61,3 +40,94 @@ class IrMailServer(models.Model):
             smtp_server=smtp_server, smtp_port=smtp_port, smtp_user=smtp_user,
             smtp_password=smtp_password, smtp_encryption=smtp_encryption,
             smtp_debug=smtp_debug, smtp_session=smtp_session)
+
+    @api.model
+    def patch_message(self, message):
+        """Override message recipients.
+
+        Result is dependent on what is specified in the configuration:
+        1. Message is not changed (no configuration or 'disabled');
+        2. Message recipients are replaced;
+        3. There is no valid recipient in the override configuration.
+
+        If there is no valid recipient, an Exception will be thrown. This
+        will be an AssertionException, in line with what is done by standard
+        Odoo. Most likely this message will be catched and an appropiate
+        reason for non delivery registered.
+        """
+        override_email_to = self.env.ref(
+            'override_mail_recipients.override_email_to',
+            raise_if_not_found=False)
+        override = override_email_to.value if override_email_to else 'disable'
+        domain_whitelist = self.env.ref(
+            'override_mail_recipients.domain_whitelist',
+            raise_if_not_found=False)
+        whitelisted_domains = [
+            '@' + domain for domain in domain_whitelist.value.split(',')
+            if '.' in domain] if domain_whitelist else []
+        if override == 'disable' and not whitelisted_domains:
+            return
+        override_recipients = \
+            extract_rfc2822_addresses(override) \
+            if override != 'disable' else []
+        assert override_recipients or whitelisted_domains, \
+            'No valid override_email_to'
+        any_mail = False
+        for field in ['to', 'cc', 'bcc']:
+            if not message[field]:
+                continue
+            any_mail = self._patch_field(
+                message, field, override_recipients, whitelisted_domains
+            ) or any_mail
+        assert any_mail, 'Attempt to send mail outside of allowed domain'
+
+    def _patch_field(
+            self, message, field, override_recipients, whitelisted_domains):
+        """Patch where needed email recipients.
+
+        - if in whitelisted or defined recipient: do not touch;
+        - if no override recipients and not whitelisted: ignore;
+        - if override recipients and not whitelisted, add textual
+          representation of email address to address of actual recipients.
+
+        return True if any address used, else False.
+        """
+        # pylint: disable=no-self-use
+        def check_recipient(recipient, valid_strings):
+            """Check wether domain, or email address in recipient."""
+            for test_string in valid_strings:
+                if test_string in recipient:
+                    return True
+            return False
+
+        actual_recipients = []
+        replaced_recipients = []
+        original_recipients = message.get_all(field, [])
+        for recipient in original_recipients:
+            in_override = check_recipient(recipient, override_recipients)
+            whitelisted = not in_override and check_recipient(
+                recipient, whitelisted_domains)
+            if whitelisted:
+                actual_recipients.append(recipient)
+            if not whitelisted and not in_override:
+                replaced_recipients.append(self._do_replacement(recipient))
+        actual_recipients += override_recipients
+        if not actual_recipients:
+            del message[field]
+            return False
+        if not replaced_recipients:
+            # Message field can be used unchanged.
+            return True
+        # Add information on replaced recipients to actual recipients.
+        del message[field]
+        replaced_string = COMMASPACE.join(replaced_recipients)
+        message[field] = COMMASPACE.join(
+            '"%s" <%s>' % (replaced_string, email)
+            for email in actual_recipients)
+        return True
+
+    def _do_replacement(self, recipient):
+        """Make recipient address into a simple string."""
+        # pylint: disable=no-self-use
+        return REPLACE_REGEX.sub(
+            lambda match: ADDRESS_REPLACEMENTS[match.group(0)], recipient)

--- a/override_mail_recipients/tests/test_ir_mail_server.py
+++ b/override_mail_recipients/tests/test_ir_mail_server.py
@@ -1,5 +1,6 @@
 # Copyright 2018-2019 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+# pylint: disable=missing-docstring,protected-access
 from odoo.tests.common import SingleTransactionCase
 
 
@@ -15,7 +16,7 @@ class TestIrMailServer(SingleTransactionCase):
             subject='Subject',
             body='test body',
             email_cc=['cc@example.com'],
-            email_bcc=['bcc@example.com'])
+            email_bcc=['bcc@someotherdomain.com'])
 
     def test_valid_override(self):
         self.env.ref(
@@ -43,3 +44,28 @@ class TestIrMailServer(SingleTransactionCase):
             self.message['to'], 'to@example.com')
         self.assertEquals(
             self.message['cc'], 'cc@example.com')
+
+    def test_domain_whitelist(self):
+        self.env.ref(
+            'override_mail_recipients.override_email_to'
+        ).value = 'disable'
+        self.env.ref(
+            'override_mail_recipients.domain_whitelist'
+        ).value = 'example.com'
+        self.env['ir.mail_server'].patch_message(self.message)
+        self.assertEquals(self.message['to'], 'to@example.com')
+        self.assertEquals(self.message['cc'], 'cc@example.com')
+        # bcc field will be fully deleted.
+        self.assertEquals(self.message['bcc'], None)
+        # Sending mail only outside of configured domain is an error.
+        self.env.ref(
+            'override_mail_recipients.domain_whitelist'
+        ).value = 'domainnotinmessage.com'
+        with self.assertRaises(AssertionError):
+            self.env['ir.mail_server'].patch_message(self.message)
+
+    def test_do_replacement(self):
+        replacement = self.env['ir.mail_server']._do_replacement(
+            '"Jansen \\ Pietersen" <jp@example.com>')
+        self.assertEquals(
+            replacement, '\\"Jansen  Pietersen\\" [jp(at)example.com]')


### PR DESCRIPTION
This was done for a customer that still wanted to test emails send to their own addresses, but still making certain no other of their partners receive emails.

Apart from the new domain whitelist functionality, I moved the send_email to the top of the code, according to the principle that main functions should be above helper functions.

(Editted after following up on the suggestions of @hbrunn ).